### PR TITLE
Update libreNMS.class.php

### DIFF
--- a/core/class/libreNMS.class.php
+++ b/core/class/libreNMS.class.php
@@ -70,7 +70,16 @@ class libreNMS extends eqLogic {
 			}
 		}
 	}
+  	public static function getDeviceHealth($deviceName) {
+		$result=self::Request('/api/v0/devices/'.$deviceName.'/health');
+		foreach($result['graphs'] as $graphs){
+			
 
+				log::add('libreNMS','debug','commande: '.$graphs['name'].'est trouvée');
+          
+		
+		}
+	}
 	/*     * *********************Methode d'instance************************* */
 	public function getARP() {
 		self::Request('/api/v0/resources/ip/arp/'.$this->getLogicalId());


### PR DESCRIPTION
je cherche a afficher dans les logs la liste des valeurs Health mais j'ai un problème pour le moment.

la valeur de $deviceName est nul, je cherche a récupérer le nom du serveur qui avait été mis dans 'name'
via cette commande $eqLogic->setName($device['hostname']);